### PR TITLE
Fix unnecessarily disabled rubocop rule

### DIFF
--- a/decidim-budgets_booth/lib/decidim/budgets_booth/voting_support.rb
+++ b/decidim-budgets_booth/lib/decidim/budgets_booth/voting_support.rb
@@ -30,7 +30,7 @@ module Decidim
         budget = budgets.first
         return true if budgets.count > 1 || budgets.count.zero?
 
-        redirect_to decidim_budgets.budget_voting_index_path(budget) and return if voting_booth_forced? # rubocop:disable Style/AndOr
+        return redirect_to decidim_budgets.budget_voting_index_path(budget) if voting_booth_forced?
 
         redirect_to decidim_budgets.budget_projects_path(budget)
       end


### PR DESCRIPTION
There is one place in the code where we have unnecessarily disabled a rubocop rule when we can just fix the problem and remove the disabling of the rule.