### PR TITLE
Update GitHub actions and change the triggers

### DIFF
--- a/.github/actions/module-rspec/action.yml
+++ b/.github/actions/module-rspec/action.yml
@@ -19,9 +19,9 @@ runs:
         node-version: 16
     - name: Get npm cache directory path
       id: npm-cache-dir-path
-      run: echo "::set-output name=dir::$(npm get cache)-${{ inputs.name }}"
+      run: echo "dir=$(npm get cache)-${{ inputs.name }}" >> $GITHUB_OUTPUT
       shell: "bash"
-    - uses: actions/cache@v2
+    - uses: actions/cache@v3
       id: npm-cache
       with:
         path: ${{ steps.npm-cache-dir-path.outputs.dir }}
@@ -34,7 +34,7 @@ runs:
     - run: mkdir -p ./spec/decidim_dummy_app/tmp/screenshots
       name: Create the screenshots folder
       shell: "bash"
-    - uses: nanasess/setup-chromedriver@v1.0.1
+    - uses: nanasess/setup-chromedriver@v2
     - run: RAILS_ENV=test bundle exec rails assets:precompile
       name: Precompile assets
       working-directory: ./spec/decidim_dummy_app/
@@ -43,8 +43,8 @@ runs:
       name: RSpec
       working-directory: ${{ inputs.name }}
       shell: "bash"
-    - uses: codecov/codecov-action@v1
-    - uses: actions/upload-artifact@v2
+    - uses: codecov/codecov-action@v3
+    - uses: actions/upload-artifact@v3
       if: always()
       with:
         name: screenshots

--- a/.github/workflows/ci_decidim-budgets_booth.yml
+++ b/.github/workflows/ci_decidim-budgets_booth.yml
@@ -1,5 +1,12 @@
 name: "[CI] BudgetsBooth"
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - develop
+      - main
+      - release/*
+      - feature/0.26/zip-code-voting
+  pull_request:
 
 env:
   CI: "true"
@@ -31,7 +38,7 @@ jobs:
       DATABASE_PASSWORD: postgres
       DATABASE_HOST: localhost
     steps:
-      - uses: actions/checkout@v2.0.0
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 1
       - uses: ./.github/actions/module-rspec

--- a/.github/workflows/ci_decidim-l10n.yml
+++ b/.github/workflows/ci_decidim-l10n.yml
@@ -1,5 +1,12 @@
 name: "[CI] L10n"
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - develop
+      - main
+      - release/*
+      - feature/0.26/zip-code-voting
+  pull_request:
 
 env:
   CI: "true"
@@ -31,7 +38,7 @@ jobs:
       DATABASE_PASSWORD: postgres
       DATABASE_HOST: localhost
     steps:
-      - uses: actions/checkout@v2.0.0
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 1
       - uses: ./.github/actions/module-rspec

--- a/.github/workflows/ci_decidim-sms-twilio.yml
+++ b/.github/workflows/ci_decidim-sms-twilio.yml
@@ -1,5 +1,12 @@
 name: "[CI] SmsTwilio"
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - develop
+      - main
+      - release/*
+      - feature/0.26/zip-code-voting
+  pull_request:
 
 env:
   CI: "true"
@@ -31,7 +38,7 @@ jobs:
       DATABASE_PASSWORD: postgres
       DATABASE_HOST: localhost
     steps:
-      - uses: actions/checkout@v2.0.0
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 1
       - uses: ./.github/actions/module-rspec

--- a/.github/workflows/ci_decidim-smsauth.yml
+++ b/.github/workflows/ci_decidim-smsauth.yml
@@ -1,5 +1,12 @@
 name: "[CI] SmsAuth"
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - develop
+      - main
+      - release/*
+      - feature/0.26/zip-code-voting
+  pull_request:
 
 env:
   CI: "true"
@@ -31,7 +38,7 @@ jobs:
       DATABASE_PASSWORD: postgres
       DATABASE_HOST: localhost
     steps:
-      - uses: actions/checkout@v2.0.0
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 1
       - uses: ./.github/actions/module-rspec

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,5 +1,12 @@
 name: "[CI] Lint"
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - develop
+      - main
+      - release/*
+      - feature/0.26/zip-code-voting
+  pull_request:
 
 env:
   CI: "true"
@@ -16,17 +23,17 @@ jobs:
     if: "!startsWith(github.head_ref, 'chore/l10n')"
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v2.0.0
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 1
       - uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
       - name: Get npm cache directory path
         id: npm-cache-dir-path
-        run: echo "::set-output name=dir::$(npm get cache)-lint"
-      - uses: actions/cache@v2
+        run: echo "dir=$(npm get cache)-lint" >> $GITHUB_OUTPUT
+      - uses: actions/cache@v3
         id: npm-cache
         with:
           path: ${{ steps.npm-cache-dir-path.outputs.dir }}


### PR DESCRIPTION
This PR updates the GitHub actions that we are using.

Also, this changes deprecated the `set-output` according to this article:
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

And additionally, I am also changing the triggers when these actions are run because currently we have the workflows running several times on PRs which is not intended, as the other run is sometimes cancelled due to the concurrency rules.