### PR TITLE
fix: Use current_order when reviewing vote

### DIFF
--- a/decidim-budgets_booth/app/controllers/concerns/decidim/budgets_booth/orders_controller_extensions.rb
+++ b/decidim-budgets_booth/app/controllers/concerns/decidim/budgets_booth/orders_controller_extensions.rb
@@ -52,10 +52,9 @@ module Decidim
         end
 
         def order
-          result = Decidim::Budgets::Order.find_by(decidim_budgets_budget_id: params[:budget_id])
-          return nil unless result && result.checked_out_at.present?
+          return unless current_order.present? && current_order.checked_out_at.present?
 
-          result
+          current_order
         end
       end
     end


### PR DESCRIPTION
#### Description

When user has voted, a button "Review your vote" is available. On click, it opens a modal and display user's vote. 
At the moment, it fetches user's vote only if the first order is checked. This PR uses existing `current_order` method in Order controller.

